### PR TITLE
Typo in a function name in a code snippet

### DIFF
--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -64,7 +64,7 @@ This will become clearer with some code. For a single data point we can calculat
 
 ```scala
 def pointLoss(a: Double, point: Point)(model: (Double, Double) => Double): Double = {
-  val error = f(point.x, a) - point.y
+  val error = model(point.x, a) - point.y
   error * error
 }
 ```


### PR DESCRIPTION
Hello! I was checking out materials for Scala Bridge event and found a small typo in the code segment explaining the loss function.

Function argument is called "model" but it's referenced as "f".