### PR TITLE
Bumping Scala version to 3.3.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import laika.rewrite.link.LinkConfig
 import laika.rewrite.link.ApiLinks
 import laika.theme.Theme
 
-val scala3 = "3.1.3"
+val scala3 = "3.3.1"
 
 ThisBuild / tlBaseVersion := "0.1" // your current series x.y
 ThisBuild / organization := "org.creativescala"


### PR DESCRIPTION
The problem with 3.1.3 is that the test runner in intellij uses 3.3.0 and it causes

```
scala: error while loading Typeable$package$,
class file scala/reflect/Typeable$package.class is broken, reading aborted with class dotty.tools.tasty.UnpickleException
TASTy signature has wrong version.
 expected: {majorVersion: 28, minorVersion: 1}
 found   : {majorVersion: 28, minorVersion: 3}

This TASTy file was produced by a more recent, forwards incompatible release.
To read this TASTy file, please upgrade your tooling.
The TASTy file was produced by Scala 3.3.0-bin-nonbootstrapped.
```

when started inside intellij.
